### PR TITLE
Toolchain

### DIFF
--- a/firmware-hc/ct-ng/.config
+++ b/firmware-hc/ct-ng/.config
@@ -1,18 +1,31 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG crosstool-ng-1.23.0-217-gaacd6f3b Configuration
+# crosstool-NG  Configuration
 #
 CT_CONFIGURE_has_static_link=y
+CT_CONFIGURE_has_cxx11=y
 CT_CONFIGURE_has_wget=y
 CT_CONFIGURE_has_curl=y
-CT_CONFIGURE_has_stat_flavor_GNU=y
 CT_CONFIGURE_has_make_3_81_or_newer=y
+CT_CONFIGURE_has_make_4_0_or_newer=y
+CT_CONFIGURE_has_libtool_2_4_or_newer=y
 CT_CONFIGURE_has_libtoolize_2_4_or_newer=y
-CT_CONFIGURE_has_autoconf_2_63_or_newer=y
-CT_CONFIGURE_has_autoreconf_2_63_or_newer=y
+CT_CONFIGURE_has_autoconf_2_65_or_newer=y
+CT_CONFIGURE_has_autoreconf_2_65_or_newer=y
 CT_CONFIGURE_has_automake_1_15_or_newer=y
 CT_CONFIGURE_has_gnu_m4_1_4_12_or_newer=y
+CT_CONFIGURE_has_python_3_4_or_newer=y
+CT_CONFIGURE_has_bison_2_7_or_newer=y
+CT_CONFIGURE_has_python=y
+CT_CONFIGURE_has_dtc=y
 CT_CONFIGURE_has_git=y
+CT_CONFIGURE_has_md5sum=y
+CT_CONFIGURE_has_sha1sum=y
+CT_CONFIGURE_has_sha256sum=y
+CT_CONFIGURE_has_sha512sum=y
+CT_CONFIGURE_has_install_with_strip_program=y
+CT_CONFIG_VERSION_CURRENT="3"
+CT_CONFIG_VERSION="3"
 CT_MODULES=y
 
 #
@@ -30,11 +43,13 @@ CT_MODULES=y
 # Paths
 #
 CT_LOCAL_TARBALLS_DIR=""
+# CT_TARBALLS_BUILDROOT_LAYOUT is not set
 CT_WORK_DIR="${CT_TOP_DIR}/.build"
-CT_BUILD_TOP_DIR="${CT_WORK_DIR}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
+CT_BUILD_TOP_DIR="${CT_WORK_DIR:-${CT_TOP_DIR}/.build}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
 CT_PREFIX_DIR="${PWD}/../toolchain/${CT_TARGET}"
 CT_RM_RF_PREFIX_DIR=y
 CT_REMOVE_DOCS=y
+CT_INSTALL_LICENSES=y
 CT_PREFIX_DIR_RO=y
 CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 # CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES is not set
@@ -51,6 +66,13 @@ CT_CONNECT_TIMEOUT=10
 CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
 # CT_ONLY_DOWNLOAD is not set
 # CT_USE_MIRROR is not set
+CT_VERIFY_DOWNLOAD_DIGEST=y
+CT_VERIFY_DOWNLOAD_DIGEST_SHA512=y
+# CT_VERIFY_DOWNLOAD_DIGEST_SHA256 is not set
+# CT_VERIFY_DOWNLOAD_DIGEST_SHA1 is not set
+# CT_VERIFY_DOWNLOAD_DIGEST_MD5 is not set
+CT_VERIFY_DOWNLOAD_DIGEST_ALG="sha512"
+# CT_VERIFY_DOWNLOAD_SIGNATURE is not set
 
 #
 # Extracting
@@ -97,6 +119,7 @@ CT_LOG_FILE_COMPRESS=y
 # Target options
 #
 # CT_ARCH_ALPHA is not set
+# CT_ARCH_ARC is not set
 CT_ARCH_ARM=y
 # CT_ARCH_AVR is not set
 # CT_ARCH_M68K is not set
@@ -109,7 +132,14 @@ CT_ARCH_ARM=y
 # CT_ARCH_X86 is not set
 # CT_ARCH_XTENSA is not set
 CT_ARCH="arm"
+CT_ARCH_CHOICE_KSYM="ARM"
 CT_ARCH_CPU="cortex-m7"
+CT_ARCH_ARM_SHOW=y
+
+#
+# Options for arm
+#
+CT_ARCH_ARM_PKG_KSYM=""
 CT_ARCH_ARM_MODE="thumb"
 # CT_ARCH_ARM_MODE_ARM is not set
 CT_ARCH_ARM_MODE_THUMB=y
@@ -117,7 +147,9 @@ CT_ARCH_ARM_MODE_THUMB=y
 CT_ARCH_ARM_EABI_FORCE=y
 CT_ARCH_ARM_EABI=y
 # CT_ARCH_ARM_TUPLE_USE_EABIHF is not set
+CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 POWERPC RISCV S390 SH SPARC X86 XTENSA"
 CT_ARCH_SUFFIX=""
+# CT_OMIT_TARGET_VENDOR is not set
 
 #
 # Generic target options
@@ -127,12 +159,11 @@ CT_DEMULTILIB=y
 CT_ARCH_SUPPORTS_BOTH_MMU=y
 CT_ARCH_DEFAULT_HAS_MMU=y
 # CT_ARCH_USE_MMU is not set
+CT_ARCH_SUPPORTS_FLAT_FORMAT=y
 CT_ARCH_SUPPORTS_EITHER_ENDIAN=y
 CT_ARCH_DEFAULT_LE=y
 # CT_ARCH_BE is not set
 CT_ARCH_LE=y
-# CT_ARCH_BE_LE is not set
-# CT_ARCH_LE_BE is not set
 CT_ARCH_ENDIAN="little"
 CT_ARCH_SUPPORTS_32=y
 CT_ARCH_SUPPORTS_64=y
@@ -207,6 +238,14 @@ CT_BARE_METAL=y
 CT_KERNEL_BARE_METAL=y
 # CT_KERNEL_LINUX is not set
 CT_KERNEL="bare-metal"
+CT_KERNEL_CHOICE_KSYM="BARE_METAL"
+CT_KERNEL_BARE_METAL_SHOW=y
+
+#
+# Options for bare-metal
+#
+CT_KERNEL_BARE_METAL_PKG_KSYM=""
+CT_ALL_KERNEL_CHOICES="BARE_METAL LINUX WINDOWS"
 
 #
 # Common kernel options
@@ -220,26 +259,45 @@ CT_ARCH_BINFMT_ELF=y
 # CT_ARCH_BINFMT_FDPIC is not set
 CT_BINUTILS_BINUTILS=y
 CT_BINUTILS="binutils"
+CT_BINUTILS_CHOICE_KSYM="BINUTILS"
+CT_BINUTILS_BINUTILS_SHOW=y
 
 #
-# GNU binutils
+# Options for binutils
 #
+CT_BINUTILS_BINUTILS_PKG_KSYM="BINUTILS"
 CT_BINUTILS_DIR_NAME="binutils"
 CT_BINUTILS_USE_GNU=y
 CT_BINUTILS_USE="BINUTILS"
 CT_BINUTILS_PKG_NAME="binutils"
 CT_BINUTILS_SRC_RELEASE=y
+CT_BINUTILS_PATCH_ORDER="global"
+# CT_BINUTILS_V_2_32 is not set
+# CT_BINUTILS_V_2_31 is not set
+# CT_BINUTILS_V_2_30 is not set
 CT_BINUTILS_V_2_29=y
-# CT_BINUTILS_V_2_28_1 is not set
+# CT_BINUTILS_V_2_28 is not set
 # CT_BINUTILS_V_2_27 is not set
-# CT_BINUTILS_V_2_26_1 is not set
-CT_BINUTILS_VERSION="2.29"
+# CT_BINUTILS_V_2_26 is not set
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.29.1"
 CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
 CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_BINUTILS_SIGNATURE_FORMAT="packed/.sig"
+CT_BINUTILS_2_30_or_older=y
+CT_BINUTILS_older_than_2_30=y
+CT_BINUTILS_later_than_2_27=y
+CT_BINUTILS_2_27_or_later=y
+CT_BINUTILS_later_than_2_25=y
 CT_BINUTILS_2_25_or_later=y
+CT_BINUTILS_later_than_2_23=y
 CT_BINUTILS_2_23_or_later=y
+
+#
+# GNU binutils
+#
 CT_BINUTILS_HAS_HASH_STYLE=y
 CT_BINUTILS_HAS_GOLD=y
 CT_BINUTILS_HAS_PLUGINS=y
@@ -253,7 +311,9 @@ CT_BINUTILS_LINKER_LD=y
 CT_BINUTILS_LINKERS_LIST="ld"
 CT_BINUTILS_LINKER_DEFAULT="bfd"
 # CT_BINUTILS_PLUGINS is not set
+CT_BINUTILS_RELRO=m
 CT_BINUTILS_EXTRA_CONFIG_ARRAY="--enable-install-libbfd"
+CT_ALL_BINUTILS_CHOICES="BINUTILS"
 
 #
 # C-library
@@ -261,20 +321,35 @@ CT_BINUTILS_EXTRA_CONFIG_ARRAY="--enable-install-libbfd"
 CT_LIBC_NEWLIB=y
 # CT_LIBC_NONE is not set
 CT_LIBC="newlib"
+CT_LIBC_CHOICE_KSYM="NEWLIB"
 CT_THREADS="none"
+CT_LIBC_NEWLIB_SHOW=y
+
+#
+# Options for newlib
+#
+CT_LIBC_NEWLIB_PKG_KSYM="NEWLIB"
 CT_NEWLIB_DIR_NAME="newlib"
 CT_NEWLIB_USE_REDHAT=y
 CT_NEWLIB_USE="NEWLIB"
 CT_NEWLIB_PKG_NAME="newlib"
 CT_NEWLIB_SRC_RELEASE=y
-CT_NEWLIB_V_2_5_0=y
-CT_NEWLIB_VERSION="2.5.0.20170720"
+CT_NEWLIB_PATCH_ORDER="global"
+# CT_NEWLIB_V_3_1 is not set
+# CT_NEWLIB_V_3_0 is not set
+CT_NEWLIB_V_2_5=y
+# CT_NEWLIB_NO_VERSIONS is not set
+CT_NEWLIB_VERSION="2.5.0.20171222"
 CT_NEWLIB_MIRRORS="ftp://sourceware.org/pub/newlib"
 CT_NEWLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_NEWLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_NEWLIB_ARCHIVE_FORMATS=".tar.gz"
+CT_NEWLIB_SIGNATURE_FORMAT=""
+CT_NEWLIB_later_than_2_2=y
 CT_NEWLIB_2_2_or_later=y
+CT_NEWLIB_later_than_2_1=y
 CT_NEWLIB_2_1_or_later=y
+CT_NEWLIB_later_than_2_0=y
 CT_NEWLIB_2_0_or_later=y
 CT_NEWLIB_CXA_ATEXIT=y
 CT_NEWLIB_HAS_NANO_MALLOC=y
@@ -301,6 +376,7 @@ CT_LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE=y
 # CT_LIBC_NEWLIB_NANO_MALLOC is not set
 # CT_LIBC_NEWLIB_NANO_FORMATTED_IO is not set
 CT_LIBC_NEWLIB_EXTRA_CONFIG_ARRAY=""
+CT_ALL_LIBC_CHOICES="AVR_LIBC BIONIC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE UCLIBC"
 CT_LIBC_SUPPORT_THREADS_NONE=y
 CT_LIBC_PROVIDES_CXA_ATEXIT=y
 
@@ -321,25 +397,40 @@ CT_CC_SUPPORT_OBJCXX=y
 CT_CC_SUPPORT_GOLANG=y
 CT_CC_GCC=y
 CT_CC="gcc"
+CT_CC_CHOICE_KSYM="GCC"
+CT_CC_GCC_SHOW=y
+
+#
+# Options for gcc
+#
+CT_CC_GCC_PKG_KSYM="GCC"
 CT_GCC_DIR_NAME="gcc"
 CT_GCC_USE_GNU=y
 CT_GCC_USE="GCC"
 CT_GCC_PKG_NAME="gcc"
 CT_GCC_SRC_RELEASE=y
-CT_GCC_V_7_2_0=y
-# CT_GCC_V_6_4_0 is not set
-# CT_GCC_V_5_4_0 is not set
-# CT_GCC_V_4_9_4 is not set
-CT_GCC_VERSION="7.2.0"
+CT_GCC_PATCH_ORDER="global"
+CT_GCC_V_8=y
+# CT_GCC_V_7 is not set
+# CT_GCC_V_6 is not set
+# CT_GCC_V_5 is not set
+# CT_GCC_V_4_9 is not set
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="8.3.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_GCC_SIGNATURE_FORMAT=""
+CT_GCC_later_than_7=y
 CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
 CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
 CT_GCC_5_or_later=y
-CT_GCC_4_9_2_or_later=y
+CT_GCC_later_than_4_9=y
 CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
 CT_GCC_4_8_or_later=y
 CT_CC_GCC_HAS_LIBMPX=y
 CT_CC_GCC_ENABLE_CXX_FLAGS=""
@@ -379,6 +470,7 @@ CT_CC_GCC_DEC_FLOAT_AUTO=y
 # CT_CC_GCC_DEC_FLOAT_BID is not set
 # CT_CC_GCC_DEC_FLOAT_DPD is not set
 # CT_CC_GCC_DEC_FLOATS_NO is not set
+CT_ALL_CC_CHOICES="GCC"
 
 #
 # Additional supported languages:
@@ -392,91 +484,131 @@ CT_CC_GCC_DEC_FLOAT_AUTO=y
 # CT_DEBUG_GDB is not set
 # CT_DEBUG_LTRACE is not set
 # CT_DEBUG_STRACE is not set
+CT_ALL_DEBUG_CHOICES="DUMA GDB LTRACE STRACE"
 
 #
 # Companion libraries
 #
-CT_COMPLIBS_NEEDED=y
-CT_GMP_NEEDED=y
-CT_MPFR_NEEDED=y
-CT_ISL_NEEDED=y
-CT_MPC_NEEDED=y
-CT_COMPLIBS=y
-# CT_LIBICONV is not set
-# CT_GETTEXT is not set
-CT_GMP=y
-CT_MPFR=y
-CT_ISL=y
-CT_MPC=y
-# CT_ZLIB is not set
-
-#
-# GMP options
-#
+# CT_COMPLIBS_CHECK is not set
+# CT_COMP_LIBS_CLOOG is not set
+# CT_COMP_LIBS_EXPAT is not set
+# CT_COMP_LIBS_GETTEXT is not set
+CT_COMP_LIBS_GMP=y
+CT_COMP_LIBS_GMP_PKG_KSYM="GMP"
 CT_GMP_DIR_NAME="gmp"
 CT_GMP_PKG_NAME="gmp"
 CT_GMP_SRC_RELEASE=y
-CT_GMP_V_6_1_2=y
+CT_GMP_PATCH_ORDER="global"
+CT_GMP_V_6_1=y
+# CT_GMP_NO_VERSIONS is not set
 CT_GMP_VERSION="6.1.2"
 CT_GMP_MIRRORS="https://gmplib.org/download/gmp https://gmplib.org/download/gmp/archive $(CT_Mirrors GNU gmp)"
 CT_GMP_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GMP_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GMP_ARCHIVE_FORMATS=".tar.xz .tar.lz .tar.bz2"
-CT_GMP_5_1_or_later=y
-
-#
-# MPFR options
-#
-CT_MPFR_DIR_NAME="mpfr"
-CT_MPFR_PKG_NAME="mpfr"
-CT_MPFR_SRC_RELEASE=y
-CT_MPFR_V_3_1_5=y
-CT_MPFR_VERSION="3.1.5"
-CT_MPFR_MIRRORS="http://www.mpfr.org/mpfr-${CT_MPFR_VERSION} $(CT_Mirrors GNU mpfr)"
-CT_MPFR_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_MPFR_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_MPFR_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz .zip"
-
-#
-# ISL options
-#
+CT_GMP_SIGNATURE_FORMAT="packed/.sig"
+CT_GMP_later_than_5_1_0=y
+CT_GMP_5_1_0_or_later=y
+CT_GMP_later_than_5_0_0=y
+CT_GMP_5_0_0_or_later=y
+CT_COMP_LIBS_ISL=y
+CT_COMP_LIBS_ISL_PKG_KSYM="ISL"
 CT_ISL_DIR_NAME="isl"
 CT_ISL_PKG_NAME="isl"
 CT_ISL_SRC_RELEASE=y
+CT_ISL_PATCH_ORDER="global"
+# CT_ISL_V_0_20 is not set
+# CT_ISL_V_0_19 is not set
 CT_ISL_V_0_18=y
-# CT_ISL_V_0_17_1 is not set
-# CT_ISL_V_0_16_1 is not set
+# CT_ISL_V_0_17 is not set
+# CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
+# CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.18"
 CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_ISL_SIGNATURE_FORMAT=""
+CT_ISL_0_18_or_later=y
+CT_ISL_0_18_or_older=y
+CT_ISL_later_than_0_15=y
 CT_ISL_0_15_or_later=y
 CT_ISL_REQUIRE_0_15_or_later=y
+CT_ISL_later_than_0_14=y
 CT_ISL_0_14_or_later=y
 CT_ISL_REQUIRE_0_14_or_later=y
+CT_ISL_later_than_0_13=y
 CT_ISL_0_13_or_later=y
+CT_ISL_later_than_0_12=y
 CT_ISL_0_12_or_later=y
 CT_ISL_REQUIRE_0_12_or_later=y
-
-#
-# MPC options
-#
+# CT_COMP_LIBS_LIBELF is not set
+# CT_COMP_LIBS_LIBICONV is not set
+CT_COMP_LIBS_MPC=y
+CT_COMP_LIBS_MPC_PKG_KSYM="MPC"
 CT_MPC_DIR_NAME="mpc"
 CT_MPC_PKG_NAME="mpc"
 CT_MPC_SRC_RELEASE=y
-CT_MPC_V_1_0_3=y
+CT_MPC_PATCH_ORDER="global"
+# CT_MPC_V_1_1 is not set
+CT_MPC_V_1_0=y
+# CT_MPC_NO_VERSIONS is not set
 CT_MPC_VERSION="1.0.3"
-CT_MPC_MIRRORS="http://www.multiprecision.org/mpc/download $(CT_Mirrors GNU mpc)"
+CT_MPC_MIRRORS="http://www.multiprecision.org/downloads $(CT_Mirrors GNU mpc)"
 CT_MPC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_MPC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_MPC_ARCHIVE_FORMATS=".tar.gz"
-
-#
-# Companion libraries common options
-#
-# CT_COMPLIBS_CHECK is not set
+CT_MPC_SIGNATURE_FORMAT="packed/.sig"
+CT_MPC_1_1_0_or_older=y
+CT_MPC_older_than_1_1_0=y
+CT_COMP_LIBS_MPFR=y
+CT_COMP_LIBS_MPFR_PKG_KSYM="MPFR"
+CT_MPFR_DIR_NAME="mpfr"
+CT_MPFR_PKG_NAME="mpfr"
+CT_MPFR_SRC_RELEASE=y
+CT_MPFR_PATCH_ORDER="global"
+CT_MPFR_V_3_1=y
+# CT_MPFR_NO_VERSIONS is not set
+CT_MPFR_VERSION="3.1.6"
+CT_MPFR_MIRRORS="http://www.mpfr.org/mpfr-${CT_MPFR_VERSION} $(CT_Mirrors GNU mpfr)"
+CT_MPFR_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_MPFR_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_MPFR_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz .zip"
+CT_MPFR_SIGNATURE_FORMAT="packed/.asc"
+CT_MPFR_4_0_0_or_older=y
+CT_MPFR_older_than_4_0_0=y
+CT_MPFR_REQUIRE_older_than_4_0_0=y
+CT_MPFR_later_than_3_0_0=y
+CT_MPFR_3_0_0_or_later=y
+# CT_COMP_LIBS_NCURSES is not set
+CT_COMP_LIBS_ZLIB=y
+CT_COMP_LIBS_ZLIB_PKG_KSYM="ZLIB"
+CT_ZLIB_DIR_NAME="zlib"
+CT_ZLIB_PKG_NAME="zlib"
+CT_ZLIB_SRC_RELEASE=y
+CT_ZLIB_PATCH_ORDER="global"
+CT_ZLIB_V_1_2_11=y
+# CT_ZLIB_NO_VERSIONS is not set
+CT_ZLIB_VERSION="1.2.11"
+CT_ZLIB_MIRRORS="http://downloads.sourceforge.net/project/libpng/zlib/${CT_ZLIB_VERSION}"
+CT_ZLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_ZLIB_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_ZLIB_SIGNATURE_FORMAT="packed/.asc"
+CT_ALL_COMP_LIBS_CHOICES="CLOOG EXPAT GETTEXT GMP ISL LIBELF LIBICONV MPC MPFR NCURSES ZLIB"
+# CT_LIBICONV_NEEDED is not set
+# CT_GETTEXT_NEEDED is not set
+CT_GMP_NEEDED=y
+CT_MPFR_NEEDED=y
+CT_ISL_NEEDED=y
+CT_MPC_NEEDED=y
+CT_ZLIB_NEEDED=y
+CT_GMP=y
+CT_MPFR=y
+CT_ISL=y
+CT_MPC=y
+CT_ZLIB=y
 
 #
 # Companion tools
@@ -484,6 +616,9 @@ CT_MPC_ARCHIVE_FORMATS=".tar.gz"
 # CT_COMP_TOOLS_FOR_HOST is not set
 # CT_COMP_TOOLS_AUTOCONF is not set
 # CT_COMP_TOOLS_AUTOMAKE is not set
+# CT_COMP_TOOLS_BISON is not set
+# CT_COMP_TOOLS_DTC is not set
 # CT_COMP_TOOLS_LIBTOOL is not set
 # CT_COMP_TOOLS_M4 is not set
 # CT_COMP_TOOLS_MAKE is not set
+CT_ALL_COMP_TOOLS_CHOICES="AUTOCONF AUTOMAKE BISON DTC LIBTOOL M4 MAKE"

--- a/firmware-hc/stm32f7xx/stm32f7xx_ll_usb.c
+++ b/firmware-hc/stm32f7xx/stm32f7xx_ll_usb.c
@@ -813,7 +813,7 @@ HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uin
 	if (dma == 0U) {
 		count32b = ((uint32_t)len + 3U) / 4U;
 		for (i = 0U; i < count32b; i++) {
-			USBx_DFIFO((uint32_t)ch_ep_num) = *((__packed uint32_t *)pSrc);
+			USBx_DFIFO((uint32_t)ch_ep_num) = *((uint32_t *)pSrc);
 			pSrc++;
 		}
 	}
@@ -842,7 +842,7 @@ void *USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len)
 	uint32_t count32b = ((uint32_t)len + 3U) / 4U;
 
 	for (i = 0U; i < count32b; i++) {
-		*(__packed uint32_t *)pDest = USBx_DFIFO(0U);
+		*(uint32_t *)pDest = USBx_DFIFO(0U);
 		pDest++;
 	}
 

--- a/firmware/ct-ng/.config
+++ b/firmware/ct-ng/.config
@@ -1,21 +1,31 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG crosstool-ng-1.23.0-217-gaacd6f3 Configuration
+# crosstool-NG  Configuration
 #
 CT_CONFIGURE_has_static_link=y
+CT_CONFIGURE_has_cxx11=y
 CT_CONFIGURE_has_wget=y
 CT_CONFIGURE_has_curl=y
-CT_CONFIGURE_has_stat_flavor_GNU=y
 CT_CONFIGURE_has_make_3_81_or_newer=y
+CT_CONFIGURE_has_make_4_0_or_newer=y
 CT_CONFIGURE_has_libtool_2_4_or_newer=y
 CT_CONFIGURE_has_libtoolize_2_4_or_newer=y
-CT_CONFIGURE_has_autoconf_2_63_or_newer=y
-CT_CONFIGURE_has_autoreconf_2_63_or_newer=y
+CT_CONFIGURE_has_autoconf_2_65_or_newer=y
+CT_CONFIGURE_has_autoreconf_2_65_or_newer=y
 CT_CONFIGURE_has_automake_1_15_or_newer=y
 CT_CONFIGURE_has_gnu_m4_1_4_12_or_newer=y
-CT_CONFIGURE_has_cvs=y
-CT_CONFIGURE_has_svn=y
+CT_CONFIGURE_has_python_3_4_or_newer=y
+CT_CONFIGURE_has_bison_2_7_or_newer=y
+CT_CONFIGURE_has_python=y
+CT_CONFIGURE_has_dtc=y
 CT_CONFIGURE_has_git=y
+CT_CONFIGURE_has_md5sum=y
+CT_CONFIGURE_has_sha1sum=y
+CT_CONFIGURE_has_sha256sum=y
+CT_CONFIGURE_has_sha512sum=y
+CT_CONFIGURE_has_install_with_strip_program=y
+CT_CONFIG_VERSION_CURRENT="3"
+CT_CONFIG_VERSION="3"
 CT_MODULES=y
 
 #
@@ -33,11 +43,13 @@ CT_MODULES=y
 # Paths
 #
 CT_LOCAL_TARBALLS_DIR=""
+# CT_TARBALLS_BUILDROOT_LAYOUT is not set
 CT_WORK_DIR="${CT_TOP_DIR}/.build"
-CT_BUILD_TOP_DIR="${CT_WORK_DIR}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
+CT_BUILD_TOP_DIR="${CT_WORK_DIR:-${CT_TOP_DIR}/.build}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
 CT_PREFIX_DIR="${PWD}/../toolchain/${CT_TARGET}"
 CT_RM_RF_PREFIX_DIR=y
 CT_REMOVE_DOCS=y
+CT_INSTALL_LICENSES=y
 CT_PREFIX_DIR_RO=y
 CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
 # CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES is not set
@@ -54,6 +66,13 @@ CT_CONNECT_TIMEOUT=10
 CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
 # CT_ONLY_DOWNLOAD is not set
 # CT_USE_MIRROR is not set
+CT_VERIFY_DOWNLOAD_DIGEST=y
+CT_VERIFY_DOWNLOAD_DIGEST_SHA512=y
+# CT_VERIFY_DOWNLOAD_DIGEST_SHA256 is not set
+# CT_VERIFY_DOWNLOAD_DIGEST_SHA1 is not set
+# CT_VERIFY_DOWNLOAD_DIGEST_MD5 is not set
+CT_VERIFY_DOWNLOAD_DIGEST_ALG="sha512"
+# CT_VERIFY_DOWNLOAD_SIGNATURE is not set
 
 #
 # Extracting
@@ -100,6 +119,7 @@ CT_LOG_FILE_COMPRESS=y
 # Target options
 #
 # CT_ARCH_ALPHA is not set
+# CT_ARCH_ARC is not set
 CT_ARCH_ARM=y
 # CT_ARCH_AVR is not set
 # CT_ARCH_M68K is not set
@@ -112,14 +132,24 @@ CT_ARCH_ARM=y
 # CT_ARCH_X86 is not set
 # CT_ARCH_XTENSA is not set
 CT_ARCH="arm"
+CT_ARCH_CHOICE_KSYM="ARM"
 CT_ARCH_CPU="cortex-m4"
+CT_ARCH_ARM_SHOW=y
+
+#
+# Options for arm
+#
+CT_ARCH_ARM_PKG_KSYM=""
 CT_ARCH_ARM_MODE="thumb"
 # CT_ARCH_ARM_MODE_ARM is not set
 CT_ARCH_ARM_MODE_THUMB=y
 # CT_ARCH_ARM_INTERWORKING is not set
 CT_ARCH_ARM_EABI_FORCE=y
 CT_ARCH_ARM_EABI=y
+# CT_ARCH_ARM_TUPLE_USE_EABIHF is not set
+CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 POWERPC RISCV S390 SH SPARC X86 XTENSA"
 CT_ARCH_SUFFIX=""
+# CT_OMIT_TARGET_VENDOR is not set
 
 #
 # Generic target options
@@ -129,12 +159,11 @@ CT_DEMULTILIB=y
 CT_ARCH_SUPPORTS_BOTH_MMU=y
 CT_ARCH_DEFAULT_HAS_MMU=y
 # CT_ARCH_USE_MMU is not set
+CT_ARCH_SUPPORTS_FLAT_FORMAT=y
 CT_ARCH_SUPPORTS_EITHER_ENDIAN=y
 CT_ARCH_DEFAULT_LE=y
 # CT_ARCH_BE is not set
 CT_ARCH_LE=y
-# CT_ARCH_BE_LE is not set
-# CT_ARCH_LE_BE is not set
 CT_ARCH_ENDIAN="little"
 CT_ARCH_SUPPORTS_32=y
 CT_ARCH_SUPPORTS_64=y
@@ -160,7 +189,7 @@ CT_ARCH_FLOAT_HW=y
 # CT_ARCH_FLOAT_SW is not set
 CT_TARGET_CFLAGS=""
 CT_TARGET_LDFLAGS=""
-CT_ARCH_FLOAT="auto"
+CT_ARCH_FLOAT="hard"
 
 #
 # Toolchain options
@@ -209,6 +238,14 @@ CT_BARE_METAL=y
 CT_KERNEL_BARE_METAL=y
 # CT_KERNEL_LINUX is not set
 CT_KERNEL="bare-metal"
+CT_KERNEL_CHOICE_KSYM="BARE_METAL"
+CT_KERNEL_BARE_METAL_SHOW=y
+
+#
+# Options for bare-metal
+#
+CT_KERNEL_BARE_METAL_PKG_KSYM=""
+CT_ALL_KERNEL_CHOICES="BARE_METAL LINUX WINDOWS"
 
 #
 # Common kernel options
@@ -222,26 +259,45 @@ CT_ARCH_BINFMT_ELF=y
 # CT_ARCH_BINFMT_FDPIC is not set
 CT_BINUTILS_BINUTILS=y
 CT_BINUTILS="binutils"
+CT_BINUTILS_CHOICE_KSYM="BINUTILS"
+CT_BINUTILS_BINUTILS_SHOW=y
 
 #
-# GNU binutils
+# Options for binutils
 #
+CT_BINUTILS_BINUTILS_PKG_KSYM="BINUTILS"
 CT_BINUTILS_DIR_NAME="binutils"
 CT_BINUTILS_USE_GNU=y
 CT_BINUTILS_USE="BINUTILS"
 CT_BINUTILS_PKG_NAME="binutils"
 CT_BINUTILS_SRC_RELEASE=y
+CT_BINUTILS_PATCH_ORDER="global"
+# CT_BINUTILS_V_2_32 is not set
+# CT_BINUTILS_V_2_31 is not set
+# CT_BINUTILS_V_2_30 is not set
 CT_BINUTILS_V_2_29=y
-# CT_BINUTILS_V_2_28_1 is not set
+# CT_BINUTILS_V_2_28 is not set
 # CT_BINUTILS_V_2_27 is not set
-# CT_BINUTILS_V_2_26_1 is not set
-CT_BINUTILS_VERSION="2.29"
+# CT_BINUTILS_V_2_26 is not set
+# CT_BINUTILS_NO_VERSIONS is not set
+CT_BINUTILS_VERSION="2.29.1"
 CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
 CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_BINUTILS_SIGNATURE_FORMAT="packed/.sig"
+CT_BINUTILS_2_30_or_older=y
+CT_BINUTILS_older_than_2_30=y
+CT_BINUTILS_later_than_2_27=y
+CT_BINUTILS_2_27_or_later=y
+CT_BINUTILS_later_than_2_25=y
 CT_BINUTILS_2_25_or_later=y
+CT_BINUTILS_later_than_2_23=y
 CT_BINUTILS_2_23_or_later=y
+
+#
+# GNU binutils
+#
 CT_BINUTILS_HAS_HASH_STYLE=y
 CT_BINUTILS_HAS_GOLD=y
 CT_BINUTILS_HAS_PLUGINS=y
@@ -255,7 +311,9 @@ CT_BINUTILS_LINKER_LD=y
 CT_BINUTILS_LINKERS_LIST="ld"
 CT_BINUTILS_LINKER_DEFAULT="bfd"
 # CT_BINUTILS_PLUGINS is not set
+CT_BINUTILS_RELRO=m
 CT_BINUTILS_EXTRA_CONFIG_ARRAY="--enable-install-libbfd"
+CT_ALL_BINUTILS_CHOICES="BINUTILS"
 
 #
 # C-library
@@ -263,20 +321,35 @@ CT_BINUTILS_EXTRA_CONFIG_ARRAY="--enable-install-libbfd"
 CT_LIBC_NEWLIB=y
 # CT_LIBC_NONE is not set
 CT_LIBC="newlib"
+CT_LIBC_CHOICE_KSYM="NEWLIB"
 CT_THREADS="none"
+CT_LIBC_NEWLIB_SHOW=y
+
+#
+# Options for newlib
+#
+CT_LIBC_NEWLIB_PKG_KSYM="NEWLIB"
 CT_NEWLIB_DIR_NAME="newlib"
 CT_NEWLIB_USE_REDHAT=y
 CT_NEWLIB_USE="NEWLIB"
 CT_NEWLIB_PKG_NAME="newlib"
 CT_NEWLIB_SRC_RELEASE=y
-CT_NEWLIB_V_2_5_0=y
-CT_NEWLIB_VERSION="2.5.0.20170720"
+CT_NEWLIB_PATCH_ORDER="global"
+# CT_NEWLIB_V_3_1 is not set
+# CT_NEWLIB_V_3_0 is not set
+CT_NEWLIB_V_2_5=y
+# CT_NEWLIB_NO_VERSIONS is not set
+CT_NEWLIB_VERSION="2.5.0.20171222"
 CT_NEWLIB_MIRRORS="ftp://sourceware.org/pub/newlib"
 CT_NEWLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_NEWLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_NEWLIB_ARCHIVE_FORMATS=".tar.gz"
+CT_NEWLIB_SIGNATURE_FORMAT=""
+CT_NEWLIB_later_than_2_2=y
 CT_NEWLIB_2_2_or_later=y
+CT_NEWLIB_later_than_2_1=y
 CT_NEWLIB_2_1_or_later=y
+CT_NEWLIB_later_than_2_0=y
 CT_NEWLIB_2_0_or_later=y
 CT_NEWLIB_CXA_ATEXIT=y
 CT_NEWLIB_HAS_NANO_MALLOC=y
@@ -303,6 +376,7 @@ CT_LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE=y
 # CT_LIBC_NEWLIB_NANO_MALLOC is not set
 # CT_LIBC_NEWLIB_NANO_FORMATTED_IO is not set
 CT_LIBC_NEWLIB_EXTRA_CONFIG_ARRAY=""
+CT_ALL_LIBC_CHOICES="AVR_LIBC BIONIC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE UCLIBC"
 CT_LIBC_SUPPORT_THREADS_NONE=y
 CT_LIBC_PROVIDES_CXA_ATEXIT=y
 
@@ -323,25 +397,40 @@ CT_CC_SUPPORT_OBJCXX=y
 CT_CC_SUPPORT_GOLANG=y
 CT_CC_GCC=y
 CT_CC="gcc"
+CT_CC_CHOICE_KSYM="GCC"
+CT_CC_GCC_SHOW=y
+
+#
+# Options for gcc
+#
+CT_CC_GCC_PKG_KSYM="GCC"
 CT_GCC_DIR_NAME="gcc"
 CT_GCC_USE_GNU=y
 CT_GCC_USE="GCC"
 CT_GCC_PKG_NAME="gcc"
 CT_GCC_SRC_RELEASE=y
-CT_GCC_V_7_2_0=y
-# CT_GCC_V_6_4_0 is not set
-# CT_GCC_V_5_4_0 is not set
-# CT_GCC_V_4_9_4 is not set
-CT_GCC_VERSION="7.2.0"
+CT_GCC_PATCH_ORDER="global"
+CT_GCC_V_8=y
+# CT_GCC_V_7 is not set
+# CT_GCC_V_6 is not set
+# CT_GCC_V_5 is not set
+# CT_GCC_V_4_9 is not set
+# CT_GCC_NO_VERSIONS is not set
+CT_GCC_VERSION="8.3.0"
 CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
 CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GCC_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_GCC_SIGNATURE_FORMAT=""
+CT_GCC_later_than_7=y
 CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
 CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
 CT_GCC_5_or_later=y
-CT_GCC_4_9_2_or_later=y
+CT_GCC_later_than_4_9=y
 CT_GCC_4_9_or_later=y
+CT_GCC_later_than_4_8=y
 CT_GCC_4_8_or_later=y
 CT_CC_GCC_HAS_LIBMPX=y
 CT_CC_GCC_ENABLE_CXX_FLAGS=""
@@ -381,6 +470,7 @@ CT_CC_GCC_DEC_FLOAT_AUTO=y
 # CT_CC_GCC_DEC_FLOAT_BID is not set
 # CT_CC_GCC_DEC_FLOAT_DPD is not set
 # CT_CC_GCC_DEC_FLOATS_NO is not set
+CT_ALL_CC_CHOICES="GCC"
 
 #
 # Additional supported languages:
@@ -394,91 +484,131 @@ CT_CC_GCC_DEC_FLOAT_AUTO=y
 # CT_DEBUG_GDB is not set
 # CT_DEBUG_LTRACE is not set
 # CT_DEBUG_STRACE is not set
+CT_ALL_DEBUG_CHOICES="DUMA GDB LTRACE STRACE"
 
 #
 # Companion libraries
 #
-CT_COMPLIBS_NEEDED=y
-CT_GMP_NEEDED=y
-CT_MPFR_NEEDED=y
-CT_ISL_NEEDED=y
-CT_MPC_NEEDED=y
-CT_COMPLIBS=y
-# CT_LIBICONV is not set
-# CT_GETTEXT is not set
-CT_GMP=y
-CT_MPFR=y
-CT_ISL=y
-CT_MPC=y
-# CT_ZLIB is not set
-
-#
-# GMP options
-#
+# CT_COMPLIBS_CHECK is not set
+# CT_COMP_LIBS_CLOOG is not set
+# CT_COMP_LIBS_EXPAT is not set
+# CT_COMP_LIBS_GETTEXT is not set
+CT_COMP_LIBS_GMP=y
+CT_COMP_LIBS_GMP_PKG_KSYM="GMP"
 CT_GMP_DIR_NAME="gmp"
 CT_GMP_PKG_NAME="gmp"
 CT_GMP_SRC_RELEASE=y
-CT_GMP_V_6_1_2=y
+CT_GMP_PATCH_ORDER="global"
+CT_GMP_V_6_1=y
+# CT_GMP_NO_VERSIONS is not set
 CT_GMP_VERSION="6.1.2"
 CT_GMP_MIRRORS="https://gmplib.org/download/gmp https://gmplib.org/download/gmp/archive $(CT_Mirrors GNU gmp)"
 CT_GMP_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GMP_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_GMP_ARCHIVE_FORMATS=".tar.xz .tar.lz .tar.bz2"
-CT_GMP_5_1_or_later=y
-
-#
-# MPFR options
-#
-CT_MPFR_DIR_NAME="mpfr"
-CT_MPFR_PKG_NAME="mpfr"
-CT_MPFR_SRC_RELEASE=y
-CT_MPFR_V_3_1_5=y
-CT_MPFR_VERSION="3.1.5"
-CT_MPFR_MIRRORS="http://www.mpfr.org/mpfr-${CT_MPFR_VERSION} $(CT_Mirrors GNU mpfr)"
-CT_MPFR_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
-CT_MPFR_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
-CT_MPFR_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz .zip"
-
-#
-# ISL options
-#
+CT_GMP_SIGNATURE_FORMAT="packed/.sig"
+CT_GMP_later_than_5_1_0=y
+CT_GMP_5_1_0_or_later=y
+CT_GMP_later_than_5_0_0=y
+CT_GMP_5_0_0_or_later=y
+CT_COMP_LIBS_ISL=y
+CT_COMP_LIBS_ISL_PKG_KSYM="ISL"
 CT_ISL_DIR_NAME="isl"
 CT_ISL_PKG_NAME="isl"
 CT_ISL_SRC_RELEASE=y
+CT_ISL_PATCH_ORDER="global"
+# CT_ISL_V_0_20 is not set
+# CT_ISL_V_0_19 is not set
 CT_ISL_V_0_18=y
-# CT_ISL_V_0_17_1 is not set
-# CT_ISL_V_0_16_1 is not set
+# CT_ISL_V_0_17 is not set
+# CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
+# CT_ISL_NO_VERSIONS is not set
 CT_ISL_VERSION="0.18"
 CT_ISL_MIRRORS="http://isl.gforge.inria.fr"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_ISL_SIGNATURE_FORMAT=""
+CT_ISL_0_18_or_later=y
+CT_ISL_0_18_or_older=y
+CT_ISL_later_than_0_15=y
 CT_ISL_0_15_or_later=y
 CT_ISL_REQUIRE_0_15_or_later=y
+CT_ISL_later_than_0_14=y
 CT_ISL_0_14_or_later=y
 CT_ISL_REQUIRE_0_14_or_later=y
+CT_ISL_later_than_0_13=y
 CT_ISL_0_13_or_later=y
+CT_ISL_later_than_0_12=y
 CT_ISL_0_12_or_later=y
 CT_ISL_REQUIRE_0_12_or_later=y
-
-#
-# MPC options
-#
+# CT_COMP_LIBS_LIBELF is not set
+# CT_COMP_LIBS_LIBICONV is not set
+CT_COMP_LIBS_MPC=y
+CT_COMP_LIBS_MPC_PKG_KSYM="MPC"
 CT_MPC_DIR_NAME="mpc"
 CT_MPC_PKG_NAME="mpc"
 CT_MPC_SRC_RELEASE=y
-CT_MPC_V_1_0_3=y
+CT_MPC_PATCH_ORDER="global"
+# CT_MPC_V_1_1 is not set
+CT_MPC_V_1_0=y
+# CT_MPC_NO_VERSIONS is not set
 CT_MPC_VERSION="1.0.3"
-CT_MPC_MIRRORS="http://www.multiprecision.org/mpc/download $(CT_Mirrors GNU mpc)"
+CT_MPC_MIRRORS="http://www.multiprecision.org/downloads $(CT_Mirrors GNU mpc)"
 CT_MPC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_MPC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_MPC_ARCHIVE_FORMATS=".tar.gz"
-
-#
-# Companion libraries common options
-#
-# CT_COMPLIBS_CHECK is not set
+CT_MPC_SIGNATURE_FORMAT="packed/.sig"
+CT_MPC_1_1_0_or_older=y
+CT_MPC_older_than_1_1_0=y
+CT_COMP_LIBS_MPFR=y
+CT_COMP_LIBS_MPFR_PKG_KSYM="MPFR"
+CT_MPFR_DIR_NAME="mpfr"
+CT_MPFR_PKG_NAME="mpfr"
+CT_MPFR_SRC_RELEASE=y
+CT_MPFR_PATCH_ORDER="global"
+CT_MPFR_V_3_1=y
+# CT_MPFR_NO_VERSIONS is not set
+CT_MPFR_VERSION="3.1.6"
+CT_MPFR_MIRRORS="http://www.mpfr.org/mpfr-${CT_MPFR_VERSION} $(CT_Mirrors GNU mpfr)"
+CT_MPFR_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_MPFR_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_MPFR_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz .zip"
+CT_MPFR_SIGNATURE_FORMAT="packed/.asc"
+CT_MPFR_4_0_0_or_older=y
+CT_MPFR_older_than_4_0_0=y
+CT_MPFR_REQUIRE_older_than_4_0_0=y
+CT_MPFR_later_than_3_0_0=y
+CT_MPFR_3_0_0_or_later=y
+# CT_COMP_LIBS_NCURSES is not set
+CT_COMP_LIBS_ZLIB=y
+CT_COMP_LIBS_ZLIB_PKG_KSYM="ZLIB"
+CT_ZLIB_DIR_NAME="zlib"
+CT_ZLIB_PKG_NAME="zlib"
+CT_ZLIB_SRC_RELEASE=y
+CT_ZLIB_PATCH_ORDER="global"
+CT_ZLIB_V_1_2_11=y
+# CT_ZLIB_NO_VERSIONS is not set
+CT_ZLIB_VERSION="1.2.11"
+CT_ZLIB_MIRRORS="http://downloads.sourceforge.net/project/libpng/zlib/${CT_ZLIB_VERSION}"
+CT_ZLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_ZLIB_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_ZLIB_SIGNATURE_FORMAT="packed/.asc"
+CT_ALL_COMP_LIBS_CHOICES="CLOOG EXPAT GETTEXT GMP ISL LIBELF LIBICONV MPC MPFR NCURSES ZLIB"
+# CT_LIBICONV_NEEDED is not set
+# CT_GETTEXT_NEEDED is not set
+CT_GMP_NEEDED=y
+CT_MPFR_NEEDED=y
+CT_ISL_NEEDED=y
+CT_MPC_NEEDED=y
+CT_ZLIB_NEEDED=y
+CT_GMP=y
+CT_MPFR=y
+CT_ISL=y
+CT_MPC=y
+CT_ZLIB=y
 
 #
 # Companion tools
@@ -486,6 +616,9 @@ CT_MPC_ARCHIVE_FORMATS=".tar.gz"
 # CT_COMP_TOOLS_FOR_HOST is not set
 # CT_COMP_TOOLS_AUTOCONF is not set
 # CT_COMP_TOOLS_AUTOMAKE is not set
+# CT_COMP_TOOLS_BISON is not set
+# CT_COMP_TOOLS_DTC is not set
 # CT_COMP_TOOLS_LIBTOOL is not set
 # CT_COMP_TOOLS_M4 is not set
 # CT_COMP_TOOLS_MAKE is not set
+CT_ALL_COMP_TOOLS_CHOICES="AUTOCONF AUTOMAKE BISON DTC LIBTOOL M4 MAKE"


### PR DESCRIPTION
Hi,

Update to the latest crosstool-ng: 1.24.0". 

The purpose is to make firmware building work out of the box in newer Linux versions too: Debian 10 and Ubuntu 20.04.

It is rather straightforward. I've updated the submodule and run `ct-ng upgradeconfig` for both firmwares.

 I've only made two additional changes:
1) disabled an experimental cosmetic feature (CT_ARCH_ARM_TUPLE_USE_EABIHF) that upgradeconfig enabled for some reason.
2) fixed compile warning caused by `__packed uint32_t*`, this is not supported  by gcc.
