### PR TITLE
Fix signet-client compiler warnings

### DIFF
--- a/signetdev/common/signetdev_common_priv.h
+++ b/signetdev/common/signetdev_common_priv.h
@@ -58,11 +58,11 @@
 #define MAX_CMD_PACKET_PAYLOAD_SIZE (MAX_BLK_SIZE + CMD_PACKET_HEADER_SIZE + 1)
 #define MAX_CMD_PACKET_BUF_SIZE (MAX_CMD_PACKET_PAYLOAD_SIZE + CMD_PACKET_HEADER_SIZE + MAX_HID_PAYLOAD_SIZE - 1)
 
-int signetdev_priv_cmd_payload_size();
+unsigned int signetdev_priv_cmd_payload_size();
 int signetdev_priv_hid_packet_size();
 int signetdev_priv_hid_payload_size();
 int signetdev_priv_startup_resp_info_size();
-int signetdev_priv_startup_resp_size();
+unsigned int signetdev_priv_startup_resp_size();
 int signetdev_priv_init_rand_data_size();
 
 //

--- a/signetdev/host/signetdev.c
+++ b/signetdev/host/signetdev.c
@@ -24,7 +24,7 @@ void *g_error_handler_param = NULL;
 
 enum signetdev_device_type g_device_type = SIGNETDEV_DEVICE_NONE;
 
-int signetdev_device_block_size()
+unsigned int signetdev_device_block_size()
 {
 	switch (g_device_type) {
 	case SIGNETDEV_DEVICE_ORIGINAL:
@@ -32,27 +32,28 @@ int signetdev_device_block_size()
 	case SIGNETDEV_DEVICE_HC:
 		return SIGNET_HC_BLK_SIZE;
 	default:
-		return -1;
+		//TODO do not ignore return error in callers of this function
+		return 0;
 	}
 }
 
-int signetdev_max_entry_data_size()
+unsigned int signetdev_max_entry_data_size()
 {
 	switch (g_device_type) {
 	case SIGNETDEV_DEVICE_ORIGINAL:
 	case SIGNETDEV_DEVICE_HC:
 		return SUB_BLK_DATA_SIZE * ((signetdev_device_block_size() - SUB_BLK_SIZE)/SUB_BLK_SIZE);
 	default:
-		return -1;
+		return 0;
 	}
 }
 
-int signetdev_device_num_root_blocks()
+unsigned int signetdev_device_num_root_blocks()
 {
 	return 1;
 }
 
-int signetdev_priv_cmd_payload_size()
+unsigned int signetdev_priv_cmd_payload_size()
 {
 	return signetdev_device_block_size() + CMD_PACKET_HEADER_SIZE + 1;
 }
@@ -92,18 +93,18 @@ int signetdev_priv_startup_resp_info_size()
 	}
 }
 
-int signetdev_priv_startup_resp_size()
+unsigned int signetdev_priv_startup_resp_size()
 {
 	switch (g_device_type) {
 	case SIGNETDEV_DEVICE_ORIGINAL:
 	case SIGNETDEV_DEVICE_HC:
 		return signetdev_priv_startup_resp_info_size() + HASH_FN_SZ + SALT_SZ_V2;
 	default:
-		return -1;
+		return 0;
 	}
 }
 
-int signetdev_device_num_storage_blocks()
+unsigned int signetdev_device_num_storage_blocks()
 {
 	switch (g_device_type) {
 	case SIGNETDEV_DEVICE_ORIGINAL:
@@ -111,18 +112,18 @@ int signetdev_device_num_storage_blocks()
 	case SIGNETDEV_DEVICE_HC:
 		return SIGNET_HC_NUM_STORAGE_BLOCKS;
 	default:
-		return -1;
+		return 0;
 	}
 }
 
-int signetdev_device_num_data_blocks()
+unsigned int signetdev_device_num_data_blocks()
 {
 	switch (g_device_type) {
 	case SIGNETDEV_DEVICE_HC:
 	case SIGNETDEV_DEVICE_ORIGINAL:
 		return signetdev_device_num_storage_blocks() - signetdev_device_num_root_blocks();
 	default:
-		return -1;
+		return 0;
 	}
 }
 

--- a/signetdev/host/signetdev.h
+++ b/signetdev/host/signetdev.h
@@ -29,11 +29,11 @@ enum signetdev_device_type signetdev_open_connection();
 void signetdev_close_connection();
 
 //Device query functions
-int signetdev_max_entry_data_size();
-int signetdev_device_block_size();
-int signetdev_device_num_data_blocks();
-int signetdev_device_num_root_blocks();
-int signetdev_device_num_storage_blocks();
+unsigned int signetdev_max_entry_data_size();
+unsigned int signetdev_device_block_size();
+unsigned int signetdev_device_num_data_blocks();
+unsigned int signetdev_device_num_root_blocks();
+unsigned int signetdev_device_num_storage_blocks();
 
 void signetdev_set_keymap(const struct signetdev_key *keys, int n_keys);
 int signetdev_can_type(const u8 *keys, int n_keys);

--- a/signetdev/host/signetdev_emulate.c
+++ b/signetdev/host/signetdev_emulate.c
@@ -69,17 +69,6 @@ static void enter_state(int state)
 	g_deviceState.n_progress_components = 0;
 }
 
-static void enter_progressing_state(int state, unsigned int components, unsigned int *maximums)
-{
-	g_deviceState.state = (enum device_state)state;
-	g_deviceState.progress_level = 0;
-	g_deviceState.n_progress_components = components;
-	for (unsigned int i = 0; i < components; i++) {
-		g_deviceState.progress_levels[i] = 0;
-		g_deviceState.progress_maximums[i] = maximums[i];
-	}
-}
-
 //
 // Database helpers
 //

--- a/signetdev/host/signetdev_unix.c
+++ b/signetdev/host/signetdev_unix.c
@@ -2,6 +2,7 @@
 #include "signetdev_priv.h"
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <pthread.h>
 #include <unistd.h>
@@ -23,8 +24,10 @@ void signetdev_close_connection()
 
 void signetdev_priv_platform_init()
 {
-	pipe(g_command_pipe);
-	pipe(g_command_resp_pipe);
+	if (pipe(g_command_pipe) == -1 || pipe(g_command_resp_pipe) == -1) {
+		perror("Signet device: Could not open pipe!");
+		exit(-1);
+	}
 	fcntl(g_command_pipe[0], F_SETFL, O_NONBLOCK);
 	pthread_create(&worker_thread, NULL, transaction_thread, NULL);
 }


### PR DESCRIPTION
With this change all the client compiler warnings are fixed. It gives me a warm and fuzzy feeling.