### PR TITLE
Use absolute URLs for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,13 +1,13 @@
 [submodule "nettle"]
 	path = firmware/nettle
-	url = ../nettle.git
+	url = https://github.com/nthdimtech/nettle.git
 	ignore = dirty
 [submodule "crosstool-ng"]
 	path = crosstool-ng
 	url = https://github.com/crosstool-ng/crosstool-ng.git
 [submodule "firmware-hc/nettle"]
 	path = firmware-hc/external/nettle
-	url = ../nettle.git
+	url = https://github.com/nthdimtech/nettle.git
 [submodule "firmware-hc/mini-gmp"]
 	path = firmware-hc/external/mini-gmp
 	url = https://github.com/chfast/mini-gmp.git


### PR DESCRIPTION
With relative URLs if I want to fork signet-client on my profile, I'll have to fork every relative submodule as well.